### PR TITLE
Add type hint to getFacadeAccessor and update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^10.17",
+        "illuminate/contracts": "^10.17|^11.0",
         "laravel/socialite": "^5.8",
         "livewire/livewire": "^2.12|^3.0",
         "spatie/laravel-package-tools": "^1.14.0",

--- a/src/Components/Layout.php
+++ b/src/Components/Layout.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\View\View;
 use Step2dev\LazyAdmin\Services\GenerateRoute;
 use Step2dev\LazyUI\LazyComponent;
 
-class LazyLayout extends LazyComponent
+class Layout extends LazyComponent
 {
     public array $routes = [];
 

--- a/src/Facades/LazyAdmin.php
+++ b/src/Facades/LazyAdmin.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Facade;
  */
 class LazyAdmin extends Facade
 {
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return \Step2dev\LazyAdmin\LazyAdmin::class;
     }

--- a/src/LazyAdminServiceProvider.php
+++ b/src/LazyAdminServiceProvider.php
@@ -10,7 +10,7 @@ use Step2dev\LazyAdmin\Commands\DbOptimize;
 use Step2dev\LazyAdmin\Commands\LazyAdminCommand;
 use Step2dev\LazyAdmin\Components\Footer;
 use Step2dev\LazyAdmin\Components\Header;
-use Step2dev\LazyAdmin\Components\LazyLayout;
+use Step2dev\LazyAdmin\Components\Layout;
 
 class LazyAdminServiceProvider extends PackageServiceProvider
 {
@@ -42,8 +42,7 @@ class LazyAdminServiceProvider extends PackageServiceProvider
                 $command
                     ->startWith(static function (InstallCommand $installCommand) {
                         $installCommand->info('Installing Lazy Admin...');
-                        $installCommand->call('php artisan lazy-ui:install');
-                        $installCommand->call('php artisan make:admin');
+                        $installCommand->call('lazy-ui:install');
                     })
                     ->publishConfigFile()
                     ->publishMigrations()
@@ -52,13 +51,15 @@ class LazyAdminServiceProvider extends PackageServiceProvider
 //                    ->publishAssets()
                     ->askToStarRepoOnGitHub('step2dev/lazy-admin')
                     ->endWith(static function (InstallCommand $installCommand) {
+                        $installCommand->call('make:admin');
+                        $installCommand->call('config:clear');
                         $installCommand->info('Lazy Admin installed successfully. Enjoy!');
                     });
             })
             ->hasViewComponents('lazy',
                 Footer::class,
                 Header::class,
-                LazyLayout::class
+                Layout::class
             )
             ->sharesDataWithAllViews('companyName', 'Step2Dev')
             ->sharesDataWithAllViews('companyUrl', 'https://step2.dev')


### PR DESCRIPTION
Updated the getFacadeAccessor to include string type hint. The dependency version for "illuminate/contracts" was updated to include "^11.0". Also, the LazyLayout component was renamed to Layout, and consequent changes were made in LazyAdminServiceProvider. The sequence of function calls in the installCommand was adjusted for readability and logic flow.