### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/step2dev/lazy-admin/security/code-scanning/2](https://github.com/step2dev/lazy-admin/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will explicitly define the permissions required for the workflow. Since the workflow primarily involves checking out code, setting up PHP, installing dependencies, and running tests, it only requires `contents: read` permissions. This change ensures that the workflow adheres to the principle of least privilege and avoids unnecessary write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
